### PR TITLE
Add nvbandwidth sample

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -27,7 +27,7 @@ on:
         default: true
 
 jobs:
-  build:
+  build-cuda-samples:
     runs-on: linux-amd64-cpu4
     strategy:
       matrix:
@@ -38,11 +38,15 @@ jobs:
         - vectorAdd
         - nbody
         - deviceQuery
+        - nvbandwidth
         exclude:
         - dist: ubi9
           sample: deviceQuery
         - dist: ubi9
           sample: nbody
+        - dist: ubi9
+          sample: nvbandwidth
+
     steps:
       - uses: actions/checkout@v4
         name: Check out code
@@ -62,7 +66,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build image
+      - name: Build cuda sample image
         env:
           IMAGE_NAME: ghcr.io/nvidia/k8s-samples
           VERSION: ${{ inputs.version }}

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -86,7 +86,8 @@ endif
 endif
 
 build-%: DIST = $(*)
-ifeq ($(SAMPLE),nbody)
+# For the following samples, we use specific Dockerfiles:
+ifeq ($(SAMPLE),$(filter $(SAMPLE),nbody nvbandwidth))
 build-%: DOCKERFILE = $(CURDIR)/deployments/container/$(SAMPLE)/Dockerfile
 else
 build-%: DOCKERFILE = $(CURDIR)/deployments/container/Dockerfile.$(DOCKERFILE_SUFFIX)

--- a/deployments/container/nvbandwidth/Dockerfile
+++ b/deployments/container/nvbandwidth/Dockerfile
@@ -1,0 +1,44 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM nvcr.io/nvidia/cuda:12.6.2-devel-ubuntu22.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    cmake \
+    g++ \
+    gcc \
+    make \
+    libboost-program-options-dev \
+    openmpi-bin \
+    openmpi-common \
+    libopenmpi-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /bandwidthtest
+
+ARG NVBANDWIDTH_VERSION=v0.7
+
+RUN git clone --branch ${NVBANDWIDTH_VERSION} --depth 1 --single-branch https://github.com/NVIDIA/nvbandwidth.git && \
+    cd nvbandwidth && \
+    cmake -DMULTINODE=1 . && \
+    make -j$(nproc)
+
+FROM mpioperator/openmpi:v0.6.0
+
+COPY --from=builder /bandwidthtest/nvbandwidth/nvbandwidth /usr/bin
+


### PR DESCRIPTION
These changes add an `nvbandwidth` CUDA sample to allow for testing GPU bandwitdth between multiple GPUs.

These chages would produce the following images:
* `docker.io/nvidia/cuda-sample:nvbandwidth-cuda12.6.2-ubuntu22.04`
*  `docker.io/nvidia/cuda-sample:nvbandwidth-cuda12.6.2`