### PR TITLE
Fix failure to build sample images

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -43,9 +43,9 @@ stages:
   variables:
     DIST: ubuntu22.04
 
-.dist-ubi8:
+.dist-ubi9:
   variables:
-    DIST: ubi8
+    DIST: ubi9
 
 # Define the platform targets
 .platform-amd64:
@@ -154,13 +154,13 @@ stages:
         OUT_IMAGE_VERSION: "${DEVEL_RELEASE_IMAGE_VERSION}"
 
 # Define the release jobs
-release:staging-vectoradd-ubi8:
+release:staging-vectoradd-ubi9:
   extends:
     - .release:staging
-    - .dist-ubi8
+    - .dist-ubi9
     - .sample-vectoradd
   needs:
-    - image-vectoradd-ubi8
+    - image-vectoradd-ubi9
 
 release:staging-vectoradd-ubuntu22.04:
   extends:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,4 +32,3 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.basic.outputs.version }}
-      build_multi_arch_images: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release-') }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -22,8 +22,9 @@ on:
         required: true
         type: string
       build_multi_arch_images:
-        required: true
+        required: false
         type: string
+        default: true
 
 jobs:
   build:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -33,15 +33,15 @@ jobs:
       matrix:
         dist:
         - ubuntu22.04
-        - ubi8
+        - ubi9
         sample:
         - vectorAdd
         - nbody
         - deviceQuery
         exclude:
-        - dist: ubi8
+        - dist: ubi9
           sample: deviceQuery
-        - dist: ubi8
+        - dist: ubi9
           sample: nbody
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          image: tonistiigi/binfmt:master
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -72,10 +72,10 @@ image-vectoradd-ubuntu22.04:
     - .dist-ubuntu22.04
     - .sample-vectoradd
 
-image-vectoradd-ubi8:
+image-vectoradd-ubi9:
   extends:
     - .image-pull
-    - .dist-ubi8
+    - .dist-ubi9
     - .sample-vectoradd
 
 image-device-query-ubuntu22.04:
@@ -160,24 +160,24 @@ scan-device-query-ubuntu22.04-arm64:
     - image-device-query-ubuntu22.04
     - scan-device-query-ubuntu22.04-amd64
 
-scan-vectoradd-ubi8-amd64:
+scan-vectoradd-ubi9-amd64:
   extends:
     - .scan
     - .sample-vectoradd
-    - .dist-ubi8
+    - .dist-ubi9
     - .platform-amd64
   needs:
-    - image-vectoradd-ubi8
+    - image-vectoradd-ubi9
 
-scan-vectoradd-ubi8-arm64:
+scan-vectoradd-ubi9-arm64:
   extends:
     - .scan
     - .sample-vectoradd
-    - .dist-ubi8
+    - .dist-ubi9
     - .platform-arm64
   needs:
-    - image-vectoradd-ubi8
-    - scan-vectoradd-ubi8-amd64
+    - image-vectoradd-ubi9
+    - scan-vectoradd-ubi9-amd64
 
 scan-nbody-ubuntu22.04-amd64:
   extends:
@@ -222,10 +222,10 @@ release:ngc-device-query-ubuntu22.04:
     - .dist-ubuntu22.04
     - .sample-device-query
 
-release:ngc-vectoradd-ubi8:
+release:ngc-vectoradd-ubi9:
   extends:
     - .release:ngc
-    - .dist-ubi8
+    - .dist-ubi9
     - .sample-vectoradd
 
 release:ngc-nbody-ubuntu22.04:

--- a/deployments/container/Dockerfile.ubi9
+++ b/deployments/container/Dockerfile.ubi9
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvidia/cuda:12.6.2-devel-ubi8 AS builder
+FROM nvcr.io/nvidia/cuda:12.6.2-devel-ubi9 AS builder
 
 ARG CUDA_VERSION
-RUN dnf install -y  \
+RUN dnf install -y --allowerasing  \
         curl \
     && \
     dnf clean all
@@ -31,7 +31,7 @@ RUN curl -L https://codeload.github.com/NVIDIA/cuda-samples/tar.gz/refs/tags/${C
     make build && \
     cp $(find /build/bin -iname "${SAMPLE_NAME}") /build/${SAMPLE_NAME}
 
-FROM nvidia/cuda:12.6.2-base-ubi8
+FROM nvcr.io/nvidia/cuda:12.6.2-base-ubi9
 ARG SAMPLE_NAME
 LABEL io.k8s.display-name="NVIDIA CUDA ${SAMPLE_NAME} sample"
 LABEL name="NVIDIA CUDA ${SAMPLE_NAME} sample"

--- a/deployments/container/Dockerfile.ubi9
+++ b/deployments/container/Dockerfile.ubi9
@@ -43,13 +43,6 @@ LABEL description="See summary"
 
 COPY ./LICENSE ./licenses/LICENSE
 
-# Install / upgrade packages here that are required to resolve CVEs
-ARG CVE_UPDATES
-RUN if [ -n "${CVE_UPDATES}" ]; then \
-        yum update -y ${CVE_UPDATES} && \
-        rm -rf /var/cache/yum/*; \
-    fi
-
 RUN mkdir -p /cuda-samples
 COPY --from=builder /build/${SAMPLE_NAME} /cuda-samples/${SAMPLE_NAME}
 

--- a/deployments/container/Dockerfile.ubi9
+++ b/deployments/container/Dockerfile.ubi9
@@ -24,7 +24,7 @@ WORKDIR /build
 
 ARG SAMPLE_NAME
 ENV SAMPLE_NAME ${SAMPLE_NAME}
-ARG CUDA_SAMPLES_VERSION=v11.6
+ARG CUDA_SAMPLES_VERSION=v12.0
 RUN curl -L https://codeload.github.com/NVIDIA/cuda-samples/tar.gz/refs/tags/${CUDA_SAMPLES_VERSION} | \
     tar -xzvf - --strip-components=1 --wildcards */${SAMPLE_NAME}/* --wildcards */Common/* && \
     cd $(find /build/Samples -iname "${SAMPLE_NAME}") && \

--- a/deployments/container/Dockerfile.ubi9
+++ b/deployments/container/Dockerfile.ubi9
@@ -14,7 +14,6 @@
 
 FROM nvcr.io/nvidia/cuda:12.6.2-devel-ubi9 AS builder
 
-ARG CUDA_VERSION
 RUN dnf install -y --allowerasing  \
         curl \
     && \
@@ -23,7 +22,7 @@ RUN dnf install -y --allowerasing  \
 WORKDIR /build
 
 ARG SAMPLE_NAME
-ENV SAMPLE_NAME ${SAMPLE_NAME}
+ENV SAMPLE_NAME=${SAMPLE_NAME}
 ARG CUDA_SAMPLES_VERSION=v12.0
 RUN curl -L https://codeload.github.com/NVIDIA/cuda-samples/tar.gz/refs/tags/${CUDA_SAMPLES_VERSION} | \
     tar -xzvf - --strip-components=1 --wildcards */${SAMPLE_NAME}/* --wildcards */Common/* && \

--- a/deployments/container/Dockerfile.ubuntu
+++ b/deployments/container/Dockerfile.ubuntu
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvidia/cuda:12.6.2-devel-ubuntu22.04 AS builder
+FROM nvcr.io/nvidia/cuda:12.6.2-devel-ubuntu22.04 AS builder
 
 ARG SAMPLE_NAME
 ENV SAMPLE_NAME ${SAMPLE_NAME}
@@ -41,7 +41,7 @@ RUN curl -L https://codeload.github.com/NVIDIA/cuda-samples/tar.gz/refs/tags/${C
     make build && \
     cp $(find /build/bin -iname "${SAMPLE_NAME}") /build/${SAMPLE_NAME}
 
-FROM nvidia/cuda:12.6.2-base-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:12.6.2-base-ubuntu22.04
 ARG SAMPLE_NAME
 LABEL io.k8s.display-name="NVIDIA CUDA ${SAMPLE_NAME} sample"
 LABEL name="NVIDIA CUDA ${SAMPLE_NAME} sample"

--- a/deployments/container/Dockerfile.ubuntu
+++ b/deployments/container/Dockerfile.ubuntu
@@ -61,13 +61,6 @@ RUN test "${SAMPLE_NAME}" = "nbody" && apt-get update && apt-get install -y --no
 
 COPY ./LICENSE ./licenses/LICENSE
 
-# Install / upgrade packages here that are required to resolve CVEs
-ARG CVE_UPDATES
-RUN if [ -n "${CVE_UPDATES}" ]; then \
-        apt-get update && apt-get upgrade -y ${CVE_UPDATES} && \
-        rm -rf /var/lib/apt/lists/*; \
-    fi
-
 RUN mkdir -p /cuda-samples
 COPY --from=builder /build/${SAMPLE_NAME} /cuda-samples/${SAMPLE_NAME}
 

--- a/deployments/container/Dockerfile.ubuntu
+++ b/deployments/container/Dockerfile.ubuntu
@@ -34,7 +34,7 @@ WORKDIR /build
 
 ARG TARGETARCH
 
-ARG CUDA_SAMPLES_VERSION=v11.6
+ARG CUDA_SAMPLES_VERSION=v12.0
 RUN curl -L https://codeload.github.com/NVIDIA/cuda-samples/tar.gz/refs/tags/${CUDA_SAMPLES_VERSION} | \
     tar -xzvf - --strip-components=1 --wildcards */${SAMPLE_NAME}/* --wildcards */Common/* && \
     cd $(find /build/Samples -iname "${SAMPLE_NAME}") && \

--- a/deployments/container/Dockerfile.ubuntu
+++ b/deployments/container/Dockerfile.ubuntu
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidia/cuda:12.6.2-devel-ubuntu22.04 AS builder
+FROM nvcr.io/nvidia/cuda:12.6.2-base-ubuntu22.04 AS builder
 
 ARG SAMPLE_NAME
-ENV SAMPLE_NAME ${SAMPLE_NAME}
+ENV SAMPLE_NAME=${SAMPLE_NAME}
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        cuda-nvcc-12-6 \
+        build-essential \
+        g++ \
         curl \
     && \
         rm -rf /var/lib/apt/lists/*

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -45,7 +45,7 @@ OUT_IMAGE_TAG ?= $(LOWER_CASE_SAMPLE)-$(OUT_IMAGE_VERSION)-$(DIST)
 OUT_IMAGE = $(OUT_IMAGE_NAME):$(OUT_IMAGE_TAG)
 
 DEFAULT_PUSH_TARGET := ubuntu22.04
-DISTRIBUTIONS := ubuntu22.04 ubi8
+DISTRIBUTIONS := ubuntu22.04 ubi9
 
 BUILD_TARGETS := $(patsubst %,build-%, $(DISTRIBUTIONS))
 PUSH_TARGETS := $(patsubst %,push-%, $(DISTRIBUTIONS))
@@ -84,7 +84,7 @@ build-%: DOCKERFILE = $(CURDIR)/deployments/container/Dockerfile.$(DOCKERFILE_SU
 
 build-ubuntu%: DOCKERFILE_SUFFIX = ubuntu
 
-build-ubi8: DOCKERFILE_SUFFIX = ubi8
+build-ubi9: DOCKERFILE_SUFFIX = ubi9
 
 # Use a generic build target to build the relevant images
 $(BUILD_TARGETS): build-%:

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -96,6 +96,5 @@ $(BUILD_TARGETS): build-%:
 		--tag $(IMAGE) \
 		--build-arg CUDA_SAMPLES_VERSION="$(CUDA_SAMPLES_VERSION)" \
 		--build-arg SAMPLE_NAME=$(SAMPLE) \
-		--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
 		-f $(DOCKERFILE) \
 		$(CURDIR)

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -80,7 +80,11 @@ endif
 endif
 
 build-%: DIST = $(*)
+ifeq ($(SAMPLE),nbody)
+build-%: DOCKERFILE = $(CURDIR)/deployments/container/$(SAMPLE)/Dockerfile
+else
 build-%: DOCKERFILE = $(CURDIR)/deployments/container/Dockerfile.$(DOCKERFILE_SUFFIX)
+endif
 
 build-ubuntu%: DOCKERFILE_SUFFIX = ubuntu
 

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -53,6 +53,12 @@ TEST_TARGETS := $(patsubst %,test-%, $(DISTRIBUTIONS))
 
 .PHONY: $(DISTRIBUTIONS) $(PUSH_TARGETS) $(BUILD_TARGETS) $(TEST_TARGETS)
 
+# Certain samples do not allow multi-arch images. We disable them here.
+# TODO: Does it make more sense to set this at a CI-level?
+ifeq ($(SAMPLE),nbody)
+BUILD_MULTI_ARCH_IMAGES = false
+endif
+
 ifneq ($(BUILD_MULTI_ARCH_IMAGES),true)
 include $(CURDIR)/deployments/container/native-only.mk
 else

--- a/deployments/container/native-only.mk
+++ b/deployments/container/native-only.mk
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
+PUSH_ON_BUILD ?= false
+ARCH ?= $(shell uname -m)
+DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/$(ARCH)
 
 $(PUSH_TARGETS): push-%:
 	$(DOCKER) tag "$(IMAGE)" "$(OUT_IMAGE)"

--- a/deployments/container/nbody/Dockerfile
+++ b/deployments/container/nbody/Dockerfile
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidia/cuda:12.6.2-devel-ubuntu22.04 AS builder
+FROM nvcr.io/nvidia/cuda:12.6.2-base-ubuntu22.04 AS builder
 
-ARG SAMPLE_NAME
-ENV SAMPLE_NAME ${SAMPLE_NAME}
+ARG SAMPLE_NAME=nbody
+ENV SAMPLE_NAME=${SAMPLE_NAME}
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl \
+        freeglut3-dev \
+        libgl1-mesa-dev \
+        libglu1-mesa-dev \
     && \
         rm -rf /var/lib/apt/lists/*
 
@@ -35,7 +37,7 @@ RUN curl -L https://codeload.github.com/NVIDIA/cuda-samples/tar.gz/refs/tags/${C
     cp $(find /build/bin -iname "${SAMPLE_NAME}") /build/${SAMPLE_NAME}
 
 FROM nvcr.io/nvidia/cuda:12.6.2-base-ubuntu22.04
-ARG SAMPLE_NAME=nbody
+ARG SAMPLE_NAME
 LABEL io.k8s.display-name="NVIDIA CUDA ${SAMPLE_NAME} sample"
 LABEL name="NVIDIA CUDA ${SAMPLE_NAME} sample"
 LABEL vendor="NVIDIA"
@@ -43,6 +45,14 @@ LABEL version="1.0.0"
 LABEL release="N/A"
 LABEL summary="NVIDIA container to validate GPU support"
 LABEL description="See summary"
+
+# The nbody sample requires libGL, libGLU, and libglut
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        freeglut3 \
+        libgl1 \
+        libglu1 \
+    && \
+        rm -rf /var/lib/apt/lists/* || :
 
 COPY ./LICENSE ./licenses/LICENSE
 


### PR DESCRIPTION
These changes address failures in building the sample images. Here we use the `base` CUDA images instead of the larger `devel` images to avoid additional packages that are not required.