### PR TITLE
Base nvbandwidth on cuda image

### DIFF
--- a/deployments/container/nvbandwidth/Dockerfile
+++ b/deployments/container/nvbandwidth/Dockerfile
@@ -38,7 +38,15 @@ RUN git clone --branch ${NVBANDWIDTH_VERSION} --depth 1 --single-branch https://
     cmake -DMULTINODE=1 . && \
     make -j$(nproc)
 
-FROM mpioperator/openmpi:v0.6.0
+FROM nvcr.io/nvidia/cuda:12.6.2-base-ubuntu22.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openmpi-bin \
+    openmpi-common \
+    libopenmpi-dev \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /bandwidthtest/nvbandwidth/nvbandwidth /usr/bin
 
+ENTRYPOINT ["mpirun"]


### PR DESCRIPTION
For OSRB compliance, we need to base the nvbandwidth image on a cuda base image. 

Single node bandwidth test with the updated base image:
```
docker run -it -e NVIDIA_IMEX_CHANNELS=0 -e NVIDIA_VISIBLE_DEVICES=all nvbandwidth:0.1 --allow-run-as-root  -n 2 nvbandwidth -p multinode_device_to_device_memcpy_read_ce
nvbandwidth Version: v0.7
Built from Git version: v0.7

MPI version: Open MPI v4.1.2, package: Debian OpenMPI, ident: 4.1.2, repo rev: v4.1.2, Nov 24, 2021
CUDA Runtime Version: 12080
CUDA Driver Version: 12080
Driver Version: 570.86.15

Process 0 (c893d00c6756): device 0: NVIDIA GH200 96GB HBM3 (00000009:01:00)
Process 1 (c893d00c6756): device 1: NVIDIA GH200 96GB HBM3 (00000019:01:00)

Running multinode_device_to_device_memcpy_read_ce.
memcpy CE GPU(row) -> GPU(column) bandwidth (GB/s)
           0         1
 0       N/A    391.93
 1    391.88       N/A

SUM multinode_device_to_device_memcpy_read_ce 783.81

NOTE: The reported results may not reflect the full capabilities of the platform.
Performance can vary with software drivers, hardware clocks, and system topology.
```