### PR TITLE
Add vulkan sample image

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -81,6 +81,13 @@ stages:
     LOWER_CASE_SAMPLE: simplemultigpu
     PUSH_SAMPLE_ONLY_TAG: "true"
 
+# Define the sample targets
+.sample-vulkan:
+  variables:
+    SAMPLE: vulkan
+    LOWER_CASE_SAMPLE: vulkan
+    PUSH_SAMPLE_ONLY_TAG: "true"
+
 # Make buildx available as a docker CLI plugin
 .buildx-setup:
   before_script:
@@ -183,4 +190,12 @@ release:staging-device-query-ubuntu22.04:
     - .sample-device-query
   needs:
     - image-device-query-ubuntu22.04
+
+release:staging-vulkan:
+  extends:
+    - .release:staging
+    - .dist-ubuntu22.04
+    - .sample-vulkan
+  needs:
+    - image-vulkan-ubuntu22.04
 

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -40,6 +40,7 @@ jobs:
         - deviceQuery
         - nvbandwidth
         - simpleMultiGPU
+        - vulkan
         exclude:
         - dist: ubi9
           sample: deviceQuery
@@ -49,6 +50,8 @@ jobs:
           sample: nvbandwidth
         - dist: ubi9
           sample: simpleMultiGPU
+        - dist: ubi9
+          sample: vulkan
 
     steps:
       - uses: actions/checkout@v4

--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -96,6 +96,12 @@ image-simple-multi-gpu-ubuntu22.04:
     - .dist-ubuntu22.04
     - .sample-simple-multi-gpu
 
+image-vulkan-ubuntu22.04:
+  extends:
+    - .image-pull
+    - .dist-ubuntu22.04
+    - .sample-vulkan
+
 # The .scan step forms the base of the image scan operation performed before releasing
 # images.
 .scan:
@@ -223,6 +229,25 @@ scan-simple-multi-gpu-ubuntu22.04-arm64:
     - image-simple-multi-gpu-ubuntu22.04
     - scan-simple-multi-gpu-ubuntu22.04-amd64
 
+scan-vulkan-ubuntu22.04-amd64:
+  extends:
+    - .scan
+    - .sample-vulkan
+    - .dist-ubuntu22.04
+    - .platform-amd64
+  needs:
+    - image-vulkan-ubuntu22.04
+
+scan-vulkan-ubuntu22.04-arm64:
+  extends:
+    - .scan
+    - .sample-vulkan
+    - .dist-ubuntu22.04
+    - .platform-arm64
+  needs:
+    - image-vulkan-ubuntu22.04
+    - scan-vulkan-ubuntu22.04-amd64
+
 # Define external release helpers
 .release:ngc:
   extends:
@@ -264,3 +289,9 @@ release:ngc-simple-multi-gpu-ubuntu22.04:
     - .release:ngc
     - .dist-ubuntu22.04
     - .sample-simple-multi-gpu
+
+release:ngc-vulkan-ubuntu22.04:
+  extends:
+    - .release:ngc
+    - .dist-ubuntu22.04
+    - .sample-vulkan

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -50,8 +50,20 @@ TEST_TARGETS := $(patsubst %,test-%, $(DISTRIBUTIONS))
 
 # Certain samples do not allow multi-arch images. We disable them here.
 # TODO: Does it make more sense to set this at a CI-level?
-ifeq ($(SAMPLE),nbody)
+AMD64_SAMPLES = vulkan
+ARM64_SAMPLES =
+SINGLE_ARCH_SAMPLES = nbody $(AMD64_SAMPLES) $(ARM64_SAMPLES)
+ifeq ($(SAMPLE),$(filter $(SAMPLE),$(SINGLE_ARCH_SAMPLES)))
+$(info Using single-architecture for $(SAMPLE))
 BUILD_MULTI_ARCH_IMAGES = false
+# Certain samples are only supported on AMD64.
+ifeq ($(SAMPLE),$(filter $(SAMPLE),$(AMD64_SAMPLES)))
+ARCH = amd64
+endif
+# Certain samples are only supported on AMD64.
+ifeq ($(SAMPLE),$(filter $(SAMPLE),$(ARM64_SAMPLES)))
+ARCH = arm64
+endif
 endif
 
 ifneq ($(BUILD_MULTI_ARCH_IMAGES),true)
@@ -82,7 +94,7 @@ endif
 
 build-%: DIST = $(*)
 # For the following samples, we use specific Dockerfiles:
-ifeq ($(SAMPLE),$(filter $(SAMPLE),nbody nvbandwidth))
+ifeq ($(SAMPLE),$(filter $(SAMPLE),nbody nvbandwidth vulkan))
 build-%: DOCKERFILE = $(CURDIR)/deployments/container/$(SAMPLE)/Dockerfile
 else
 build-%: DOCKERFILE = $(CURDIR)/deployments/container/Dockerfile.$(DOCKERFILE_SUFFIX)

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -14,10 +14,7 @@
 
 BUILD_MULTI_ARCH_IMAGES ?= false
 DOCKER ?= docker
-BUILDX  =
-ifeq ($(BUILD_MULTI_ARCH_IMAGES),true)
-BUILDX = buildx
-endif
+BUILDX =
 MKDIR  ?= mkdir
 
 include $(CURDIR)/versions.mk
@@ -42,9 +39,10 @@ OUT_IMAGE = $(OUT_IMAGE_NAME):$(OUT_IMAGE_TAG)
 DEFAULT_PUSH_TARGET := ubuntu22.04
 DISTRIBUTIONS := ubuntu22.04 ubi9
 
-BUILD_TARGETS := $(patsubst %,build-%, $(DISTRIBUTIONS))
-PUSH_TARGETS := $(patsubst %,push-%, $(DISTRIBUTIONS))
-TEST_TARGETS := $(patsubst %,test-%, $(DISTRIBUTIONS))
+IMAGE_TARGETS := $(patsubst %,image-%,$(DISTRIBUTIONS))
+BUILD_TARGETS := $(patsubst %,build-%,$(DISTRIBUTIONS))
+PUSH_TARGETS := $(patsubst %,push-%,$(DISTRIBUTIONS))
+TEST_TARGETS := $(patsubst %,test-%,$(DISTRIBUTIONS))
 
 .PHONY: $(DISTRIBUTIONS) $(PUSH_TARGETS) $(BUILD_TARGETS) $(TEST_TARGETS)
 
@@ -64,6 +62,11 @@ endif
 ifeq ($(SAMPLE),$(filter $(SAMPLE),$(ARM64_SAMPLES)))
 ARCH = arm64
 endif
+endif
+
+# If BUILD_MULTI_ARCH_IMAGES is still true for a given set of samples, we enable buildx.
+ifeq ($(BUILD_MULTI_ARCH_IMAGES),true)
+BUILDX = buildx
 endif
 
 ifneq ($(BUILD_MULTI_ARCH_IMAGES),true)
@@ -105,7 +108,7 @@ build-ubuntu%: DOCKERFILE_SUFFIX = ubuntu
 build-ubi9: DOCKERFILE_SUFFIX = ubi9
 
 # Use a generic build target to build the relevant images
-$(BUILD_TARGETS): build-%:
+$(IMAGE_TARGETS): image-%:
 	DOCKER_BUILDKIT=1 \
 		$(DOCKER) $(BUILDX) build --pull \
 		--provenance=false --sbom=false \
@@ -116,3 +119,20 @@ $(BUILD_TARGETS): build-%:
 		--build-arg SAMPLE_NAME=$(SAMPLE) \
 		-f $(DOCKERFILE) \
 		$(CURDIR)
+
+# Handle the default build target.
+.PHONY: build
+build: $(DEFAULT_PUSH_TARGET)
+$(DEFAULT_PUSH_TARGET): build-$(DEFAULT_PUSH_TARGET)
+$(DEFAULT_PUSH_TARGET): DIST = $(DEFAULT_PUSH_TARGET)
+
+REGCTL ?= regctl
+$(PUSH_TARGETS): push-%:
+	$(REGCTL) \
+	        image copy \
+	        $(IMAGE) $(OUT_IMAGE)
+
+push-short:
+	$(REGCTL) \
+	        image copy \
+	        $(IMAGE) $(OUT_IMAGE_NAME):$(OUT_IMAGE_VERSION)

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -22,11 +22,6 @@ MKDIR  ?= mkdir
 
 include $(CURDIR)/versions.mk
 
-ifeq ($(IMAGE_NAME),)
-REGISTRY ?= nvidia
-IMAGE_NAME := $(REGISTRY)/cuda-sample
-endif
-
 # The Makefile describes the build process for a single CUDA sample: e.g. `vectorAdd`
 ifeq ($(SAMPLE),)
 # Use vectorAdd as the default sample

--- a/deployments/container/multi-arch.mk
+++ b/deployments/container/multi-arch.mk
@@ -16,18 +16,4 @@ PUSH_ON_BUILD ?= false
 DOCKER_BUILD_OPTIONS = --output=type=image,push=$(PUSH_ON_BUILD)
 DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64,linux/arm64
 
-REGCTL ?= regctl
-$(PUSH_TARGETS): push-%:
-	$(REGCTL) \
-	        image copy \
-	        $(IMAGE) $(OUT_IMAGE)
-
-push-short:
-	$(REGCTL) \
-	        image copy \
-	        $(IMAGE) $(OUT_IMAGE_NAME):${LOWER_CASE_SAMPLE}-$(OUT_IMAGE_VERSION)
-
-push-sample:
-	$(REGCTL) \
-	        image copy \
-	        $(IMAGE) $(OUT_IMAGE_NAME):$(LOWER_CASE_SAMPLE)
+$(BUILD_TARGETS): build-%: image-%

--- a/deployments/container/vulkan/Dockerfile
+++ b/deployments/container/vulkan/Dockerfile
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM nvcr.io/nvidia/cuda:12.8.1-base-ubuntu22.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    wget \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+# See instructions from https://vulkan.lunarg.com/doc/sdk/1.4.309.0/linux/getting_started_ubuntu.html
+RUN wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | tee /etc/apt/trusted.gpg.d/lunarg.asc \
+    && \
+    wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list http://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list \
+    && \
+    apt update -y \
+    && \
+    apt install -y --no-install-recommends vulkan-sdk \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+# TODO: Should we include this in the list above.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    make \
+    cmake \
+    pkg-config \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+ARG BUILD_EXAMPLES="computeheadless renderheadless"
+ENV BUILD_EXAMPLES=$BUILD_EXAMPLES
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libglm-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# TODO: We should update to the official samples
+RUN git clone --depth=1 https://github.com/SaschaWillems/Vulkan.git \
+    && cd Vulkan \
+    sed -e 's|https://|git@|g' .gitmodules \
+    && \
+    git submodule sync \
+    && \
+    git submodule update \
+    && mkdir -p build && cd build \
+    && cmake -D RESOURCE_INSTALL_DIR=/cuda-samples ..  \
+    && make ${BUILD_EXAMPLES}
+
+FROM nvcr.io/nvidia/cuda:12.8.1-base-ubuntu22.04
+
+LABEL io.k8s.display-name="NVIDIA CUDA Vulkan samples"
+LABEL name="NVIDIA CUDA Vulkan samples"
+LABEL vendor="NVIDIA"
+LABEL version="N/A"
+LABEL release="N/A"
+LABEL summary="NVIDIA container to validate GPU support for Vulkan"
+LABEL description="See summary"
+
+COPY ./LICENSE ./licenses/LICENSE
+
+RUN mkdir -p /cuda-samples
+
+COPY --from=builder /build/Vulkan/build/bin/computeheadless /cuda-samples/bin/computeheadless
+COPY --from=builder /build/Vulkan/build/bin/renderheadless /cuda-samples/bin/renderheadless
+COPY --from=builder /build/Vulkan/shaders/glsl/computeheadless/ /cuda-samples/shaders/glsl/computeheadless/
+COPY --from=builder /build/Vulkan/shaders/glsl/renderheadless/ /cuda-samples/shaders/glsl/renderheadless/
+COPY --from=builder /build/Vulkan/shaders/hlsl/computeheadless/ /cuda-samples/shaders/hlsl/computeheadless/
+COPY --from=builder /build/Vulkan/shaders/hlsl/renderheadless/ /cuda-samples/shaders/hlsl/renderheadless/
+
+COPY /deployments/container/vulkan/entrypoint.sh /cuda-samples/entrypoint.sh
+RUN ln -s /cuda-samples/entrypoint.sh /cuda-samples/sample
+
+ENV DEBIAN_FRONTEND=noninteractive
+COPY --from=builder /etc/apt/sources.list.d/lunarg-vulkan-jammy.list /etc/apt/sources.list.d/lunarg-vulkan-jammy.list
+COPY --from=builder /etc/apt/trusted.gpg.d/lunarg.asc /etc/apt/trusted.gpg.d/lunarg.asc
+
+RUN apt update -y && apt install -y --no-install-recommends \
+        vulkan-sdk \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["/cuda-samples/sample"]

--- a/deployments/container/vulkan/entrypoint.sh
+++ b/deployments/container/vulkan/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+EXAMPLES=/cuda-samples/bin/
+for i in $(ls ${EXAMPLES}); do
+        echo 'y' | ${EXAMPLES}/$i
+        echo "\n"
+done

--- a/versions.mk
+++ b/versions.mk
@@ -18,3 +18,8 @@ VERSION ?= cuda$(shell  grep -Eo "FROM.*cuda:[0-9\.]+" deployments/container/Doc
 # Specify the tag for the https://github.com/NVIDIA/cuda-samples repository.
 # This need not match the CUDA_VERSION above.
 CUDA_SAMPLES_VERSION := v12.0
+
+ifeq ($(IMAGE_NAME),)
+REGISTRY ?= nvcr.io/nvidia/k8s
+IMAGE_NAME := $(REGISTRY)/cuda-sample
+endif


### PR DESCRIPTION
This change adds a vulkan sample image to replace the image(s) defined at https://gitlab.com/nvidia/container-images/vulkan

```
$ docker run --rm -ti --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=runtime.nvidia.com/gpu=all ghcr.io/nvidia/k8s-samples:vulkan-38c01b50-ubuntu22.04
Running headless compute example
GPU: Tesla V100-SXM2-16GB-N
Compute input:
0       1       2       3       4       5       6       7       8       9       10      11      12      13      14      15      16      17      18      19      20      21      22      23      24      25      26 27      28      29      30      31
Compute output:
0       1       1       2       3       5       8       13      21      34      55      89      144     233     377     610     987     1597    2584    4181    6765    10946   17711   28657   46368   75025   121393     196418  317811  514229  832040  1346269
Finished. Press enter to terminate...\n
Running headless rendering example
GPU: Tesla V100-SXM2-16GB-N
Framebuffer image saved to headless.ppm
Finished. Press enter to terminate...\n
```