### PR TITLE
Add sshd to nvbandwidth sample 

### DIFF
--- a/deployments/container/nvbandwidth/Dockerfile
+++ b/deployments/container/nvbandwidth/Dockerfile
@@ -45,7 +45,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openmpi-common \
     libopenmpi-dev \
     openssh-client \
+    openssh-server \
     && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /var/run/sshd
 
 COPY --from=builder /bandwidthtest/nvbandwidth/nvbandwidth /usr/bin
 

--- a/deployments/container/nvbandwidth/Dockerfile
+++ b/deployments/container/nvbandwidth/Dockerfile
@@ -40,6 +40,8 @@ RUN git clone --branch ${NVBANDWIDTH_VERSION} --depth 1 --single-branch https://
 
 FROM nvcr.io/nvidia/cuda:12.6.2-base-ubuntu22.04
 
+ARG port=2222
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openmpi-bin \
     openmpi-common \
@@ -49,6 +51,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /var/run/sshd
+
+# Got it from mpi-operator/build/base/Dockerfile
+# Allow OpenSSH to talk to containers without asking for confirmation
+# by disabling StrictHostKeyChecking.
+# mpi-operator mounts the .ssh folder from a Secret. For that to work, we need
+# to disable UserKnownHostsFile to avoid write permissions.
+# Disabling StrictModes avoids directory and files read permission checks.
+RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
+    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
+    sed -i "s/[ #]\(.*Port \).*/ \1$port/g" /etc/ssh/ssh_config && \
+    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
+    sed -i "s/#\(Port \).*/\1$port/g" /etc/ssh/sshd_config
+
+RUN useradd -m mpiuser
+WORKDIR /home/mpiuser
+
+COPY --chown=mpiuser ./deployments/container/nvbandwidth/sshd_config .sshd_config
+RUN echo "Port $port" >> /home/mpiuser/.sshd_config
 
 COPY --from=builder /bandwidthtest/nvbandwidth/nvbandwidth /usr/bin
 

--- a/deployments/container/nvbandwidth/sshd_config
+++ b/deployments/container/nvbandwidth/sshd_config
@@ -1,0 +1,3 @@
+PidFile /home/mpiuser/sshd.pid
+HostKey /home/mpiuser/.ssh/id_rsa
+StrictModes no


### PR DESCRIPTION
Need openssh-server to fix this error 

```
Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/usr/sbin/sshd": stat /usr/sbin/sshd: no such file or directory: unknown
```