### PR TITLE
Revert back to tonistiigi/binfmt:qemu-v7.0.0

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -30,6 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         dist:
         - ubuntu22.04

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          image: tonistiigi/binfmt:qemu-v9.2.2
+          image: tonistiigi/binfmt:qemu-v7.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
The bump to v9.2.2 from #33 seems to still be causing flakes.

The v7.0.0 version is stated to address the glibc segfaults here https://github.com/tonistiigi/binfmt/issues/240#issuecomment-2669862784