### PR TITLE
Revert to regctl v0.4.5

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -49,7 +49,7 @@ workflow:
 # Download the regctl binary for use in the release steps
 .regctl-setup:
   before_script:
-    - export REGCTL_VERSION=v0.9.0
+    - export REGCTL_VERSION=v0.4.5
     - apk add --no-cache curl
     - mkdir -p bin
     - curl -sSLo bin/regctl https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64


### PR DESCRIPTION
The v0.9.0 bump may be causing issues loging into the registry: https://gitlab-master.nvidia.com/dl/container-dev/cuda-sample-images/-/jobs/185318996

Reverting to v0.4.5 fixes this issue: https://gitlab-master.nvidia.com/dl/container-dev/cuda-sample-images/-/jobs/185321184