### PR TITLE
Upgrade nvbandwidth to v0.9

### DIFF
--- a/deployments/container/nvbandwidth/Dockerfile
+++ b/deployments/container/nvbandwidth/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /bandwidthtest
 
-ARG NVBANDWIDTH_VERSION=v0.8
+ARG NVBANDWIDTH_VERSION=v0.9
 
 RUN git clone --branch ${NVBANDWIDTH_VERSION} --depth 1 --single-branch https://github.com/NVIDIA/nvbandwidth.git && \
     cd nvbandwidth && \


### PR DESCRIPTION
https://github.com/NVIDIA/nvbandwidth/releases/tag/v0.9 was released back in April, please can we upgrade to use it?

Thanks,

Rob